### PR TITLE
feat: add generateAccessWrapper

### DIFF
--- a/src/AccessWrapper/generateAccessWrapper.tsx
+++ b/src/AccessWrapper/generateAccessWrapper.tsx
@@ -1,0 +1,23 @@
+import { SESSIONS_STATUS } from "../useAuth/useAuth";
+import { State } from "../useAuth/useAuth";
+import { StoreApi, UseBoundStore } from "zustand";
+
+export interface AccessWrapperProps {
+  profiles: string[];
+  route: boolean;
+  children: React.ReactNode;
+}
+
+export const generateAccessWrapper = (
+  useAuthInstance: UseBoundStore<StoreApi<State>>,
+  loaderComponent: React.ReactNode,
+  errorComponent: React.ReactNode
+) => (
+  function AccessWrapper({ profiles = [], route, children }: AccessWrapperProps) {
+    const { hasProfiles, sessionStatus } = useAuthInstance();
+
+    if (route && sessionStatus === SESSIONS_STATUS.LOADING) return loaderComponent;
+    if (route && !hasProfiles(profiles)) return errorComponent;
+    if (hasProfiles(profiles)) return (children);
+  }
+);

--- a/src/useAuth/useAuth.tsx
+++ b/src/useAuth/useAuth.tsx
@@ -49,7 +49,7 @@ export interface Profile {
   profile_name: string;
 }
 
-interface State {
+export interface State {
   user: User | null;
   profiles: Profile[];
   sessionStatus: SESSION_STATUS;


### PR DESCRIPTION
This pull request introduces a new `generateAccessWrapper` function in `src/AccessWrapper/generateAccessWrapper.tsx` and modifies the `State` interface in `src/useAuth/useAuth.tsx` to be exported. These changes aim to enhance the authentication and profile management in the application.

Enhancements to authentication and profile management:

* [`src/AccessWrapper/generateAccessWrapper.tsx`](diffhunk://#diff-1f602516f6274577b2149ea924c0c8aa17f3f9dd81378d7534e84f1b6caa5817R1-R23): Added a new `generateAccessWrapper` function to create a higher-order component for managing access based on user profiles and session status. This function takes `useAuthInstance`, `loaderComponent`, and `errorComponent` as parameters and returns an `AccessWrapper` component. (`[src/AccessWrapper/generateAccessWrapper.tsxR1-R23](diffhunk://#diff-1f602516f6274577b2149ea924c0c8aa17f3f9dd81378d7534e84f1b6caa5817R1-R23)`)
* [`src/useAuth/useAuth.tsx`](diffhunk://#diff-bfb06608a25a16e9a591f22e2da48361be44ea4ed3239fb6e9b9b8499df5035aL52-R52): Modified the `State` interface to be exported, allowing it to be used in other parts of the application. (`[src/useAuth/useAuth.tsxL52-R52](diffhunk://#diff-bfb06608a25a16e9a591f22e2da48361be44ea4ed3239fb6e9b9b8499df5035aL52-R52)`)